### PR TITLE
One-letter AM/PM support

### DIFF
--- a/holobot.go
+++ b/holobot.go
@@ -154,7 +154,7 @@ func main() {
 			Description: "Displays times mentioned in the message in various relevant time zones.",
 			Handler: func(event *model.WebSocketEvent, post *model.Post) error {
 				// regex to match valid times with time zones (ex. "1 GMT", "2:00 AM EST", "15:00 PT", etc.)
-				re := regexp.MustCompile(`([0-9]{1,2})(:[0-9]{1,2})? *([paPA]\.?[mM]\.?)? +([A-Za-z][a-zA-Z]+)((\+|\-)([0-9]{1,2})(?:\s|\W|$))?`) // big ol' hairy regex
+				re := regexp.MustCompile(`([0-9]{1,2})(:[0-9]{1,2})? *([paPA]\.?[mM]?\.?)? +([A-Za-z][a-zA-Z]+)((\+|\-)([0-9]{1,2})(?:\s|\W|$))?`) // big ol' hairy regex
 				if matches := re.FindAllStringSubmatch(post.Message, -1); matches != nil {
 					for _, m := range matches {
 						layout := "15"


### PR DESCRIPTION
changed the regex so that the M in AM or PM is optional. The meaning
still comes through because of the changes to AM/PM parsing zippy did to
make "a.m." and "p.m." work.